### PR TITLE
Propagate -static-stdlib for wasm32

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -1105,7 +1105,7 @@ public final class ProductBuildDescription {
             if buildParameters.shouldLinkStaticSwiftStdlib {
                 if buildParameters.triple.isDarwin() {
                     diagnostics.emit(.swiftBackDeployError)
-                } else if buildParameters.triple.isLinux() {
+                } else if buildParameters.triple.isLinux() || buildParameters.triple.arch == .wasm32 {
                     args += ["-static-stdlib"]
                 }
             }


### PR DESCRIPTION
We need to pass `-static-swift-stdlib` to link static stdlib, Foundation and XCTest. But current implementation propagate that flag only for Linux, so I changed to allow it for wasm32