### PR TITLE
Stop inheriting extra flags from host destination for 5.3

### DIFF
--- a/Sources/Commands/SwiftTool.swift
+++ b/Sources/Commands/SwiftTool.swift
@@ -835,10 +835,14 @@ public class SwiftTool<Options: ToolOptions> {
             // in Swift toolchain
             do {
                 let compilers = try UserToolchain.determineSwiftCompilers(binDir: destination.binDir)
-                destination.sdk = compilers.compile
+                let wasiSysroot = compilers.compile
                     .parentDirectory // bin
                     .parentDirectory // usr
                     .appending(components: "share", "wasi-sysroot")
+                destination = Destination(
+                    target: target, sdk: wasiSysroot, binDir: destination.binDir,
+                    extraCCFlags: [], extraSwiftCFlags: [], extraCPPFlags: []
+                )
             } catch {
                 return .failure(error)
             }


### PR DESCRIPTION
Host destination has extra flags to include XCTest but it conflicts with our lib/swift_static dir https://github.com/apple/swift-package-manager/blob/27f444f6df6acb832e3060f58517f9d4e91e4bec/Sources/Workspace/Destination.swift#L121-L126