### PR TITLE
Add Wasm and its features to SupportedPlatforms

### DIFF
--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -388,7 +388,7 @@ extension SupportedPlatform {
         /// WebAssembly System Interface is available.
         static let wasi = WasmFeatures(rawValue: 1 << 0)
 
-        /// Shared linear memory and atomic memory access is available.
+        /// Shared linear memory and atomic memory access are available.
         static let atomics = WasmFeatures(rawValue: 1 << 1)
 
         /// Fixed-width SIMD is available.

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -45,6 +45,9 @@ public struct Platform: Encodable {
     /// The WebAssembly System Interface platform.
     @available(_PackageDescription, introduced: 5.3)
     public static let wasi: Platform = Platform(name: "wasi")
+
+    /// The WebAssembly platform.
+    public static let wasm: Platform = Platform(name: "wasm")
 }
 
 /// A platform that the Swift package supports.
@@ -65,17 +68,20 @@ public struct Platform: Encodable {
 /// target of a package's dependencies must be lower than or equal to the top-level package's
 /// deployment target version for a particular platform.
 public struct SupportedPlatform: Encodable {
-
     /// The platform.
     let platform: Platform
 
     /// The platform version.
     let version: String?
 
+    /// The platform features.
+    let features: Int64?
+
     /// Creates supported platform instance.
-    init(platform: Platform, version: String? = nil) {
+    init(platform: Platform, version: String? = nil, features: Int64? = nil) {
         self.platform = platform
         self.version = version
+        self.features = features
     }
 
     /// Configures the minimum deployment target version for the macOS platform.
@@ -160,6 +166,10 @@ public struct SupportedPlatform: Encodable {
     /// - Parameter versionString: The minimum deployment target as a string representation of two or three dot-separated integers, such as `2.0.1`.
     public static func watchOS(_ versionString: String) -> SupportedPlatform {
         return SupportedPlatform(platform: .watchOS, version: SupportedPlatform.WatchOSVersion(string: versionString).version)
+    }
+
+    public static func wasm(_ features: WasmFeatures) -> SupportedPlatform {
+        return SupportedPlatform(platform: .wasm, features: features.rawValue)
     }
 }
 
@@ -361,6 +371,28 @@ extension SupportedPlatform {
         /// - Since: First available in PackageDescription 5.3
         @available(_PackageDescription, introduced: 5.3)
         public static let v7: WatchOSVersion = .init(string: "7.0")
+    }
+
+    /// The supported WebAssembly features.
+    public struct WasmFeatures: Encodable, OptionSet {
+        public init(rawValue: Int64) {
+            self.rawValue = rawValue
+        }
+
+        /// The underlying features representation.
+        public let rawValue: Int64
+
+        /// Minimum available feature set.
+        static let mvp = WasmFeatures([])
+
+        /// WebAssembly System Interface is available.
+        static let wasi = WasmFeatures(rawValue: 1 << 0)
+
+        /// Shared linear memory and atomic memory access is available.
+        static let atomics = WasmFeatures(rawValue: 1 << 1)
+
+        /// Fixed-width SIMD is available.
+        static let simd = WasmFeatures(rawValue: 1 << 2)
     }
 }
 


### PR DESCRIPTION
Here's a proposal for how specifying requirements for atomics/SIMD and other features could look in `Package.swift`:

```swift
// swift-tools-version:5.4
import PackageDescription

let package = Package(
    name: "SwiftWasmApp",
    platforms: [.wasm(.atomics)]
    // all other package settings omitted here as irrelevant
)
```

Not all Wasm features are specified in this PR, as some of them are too low-level. I've only picked a few that could be useful in the near future, but the list can be easily expanded (as long as we don't have more than 64 features).

I want to start this discussion now, so that we propose this upstream as soon as possible in time for the Swift 5.4 merge window. [The preliminary schedule](https://forums.swift.org/t/accepted-se-0289-result-builders/41377/3) is that Swift 5.4 will be released in spring 2021, so I guess it'll be tagged with no possibility to merge changes as big as this one after this December-January? Either way, if we miss the window, we'll have to wait some indefinite amount of time for it to land in the Swift version after that. If we make it in time, we'll be able to start specifying these features in `Package.swift` manifests that can be depended on other libraries for other platforms.

I want to get your feedback before submitting this upstream. One alternative could be to use browser versions instead of Wasm features, i.e.:

```swift
// swift-tools-version:5.4
import PackageDescription

let package = Package(
    name: "SwiftWasmApp",
    platforms: [.chrome(68), .safari(15), .firefox(79)]
    // all other package settings omitted here as irrelevant
)
```

In the latter case I guess some part of the toolchain (or just `carton` itself short-term) would have to maintain a database of what features are available in what browser versions. But in the end that would require more infrastructure changes to work. Additionally, these options are not mutually exclusive, I hope. `.wasm(.atomics)` could be useful for non-browser WebAssembly hosts, while `.firefox(79)` would imply a JavaScript environment and DOM availability, which is also useful to encode in platform requirements.

WDYT?