### PR TITLE
Fix Bundle compilation with LTO

### DIFF
--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -876,6 +876,7 @@ public final class SwiftTargetBuildDescription {
         result += buildParameters.targetTripleArgs(for: target)
         result += ["-swift-version", swiftVersion.rawValue]
 
+        result += buildParameters.indexStoreArguments(for: target)
         result += buildParameters.toolchain.extraSwiftCFlags
         result += optimizationArguments
         result += testingArguments
@@ -884,6 +885,7 @@ public final class SwiftTargetBuildDescription {
         result += activeCompilationConditions
         result += additionalFlags
         result += moduleCacheArgs
+        result += stdlibArguments
         result += buildParameters.sanitizers.compileSwiftFlags()
         result += self.buildSettingsFlags()
         result += buildParameters.swiftCompilerFlags

--- a/Sources/Build/BuildPlan.swift
+++ b/Sources/Build/BuildPlan.swift
@@ -851,9 +851,7 @@ public final class SwiftTargetBuildDescription {
             result.append("-parse-as-library")
         }
 
-        for source in target.sources.paths {
-            result.append(source.pathString)
-        }
+        result.append(contentsOf: sources.map { $0.pathString })
 
         // FIXME: Support partial sib and bc emission
         result.append("-whole-module-optimization")


### PR DESCRIPTION
_[One line description of your change]_

### Motivation:

Fix https://github.com/swiftwasm/swift/issues/2195

### Modifications:

- [[LTO] Sync newly added shared arguments for summary emission](https://github.com/swiftwasm/swift-package-manager/commit/64ac1ff1c88b4c3a8f6cc4385511897223267d19)
- [[LTO] Compile derived sources as module inputs](https://github.com/swiftwasm/swift-package-manager/commit/c2b6e60bfa90ed29daad4821ab06738764ff9b37)

### Result:

_[After your change, what will change.]_
